### PR TITLE
Reformatting of titles and insertion of hyperlinks

### DIFF
--- a/content/weekplan.qmd
+++ b/content/weekplan.qmd
@@ -1,63 +1,94 @@
 
 # Schedule {.unnumbered}
 
+*Reading*: The material you should become familiar with during the week.
+*Lectures*: The important points and concepts summarized.
+*Exercises*: The exercises to be completed by the end of the TA session.
+
+<!--
+-------------------------------------------------------------------------------
+-->
 
 ## Week 1 {.unnumbered}
 
-##### Reading:  
-- I will cover chapters 1-7 in the lecture notes. Make sure you have installed Python and VScode for the first lecture.
+### Reading:
 
-##### Lectures:  
+I will cover chapters 1-7 in the lecture notes. Make sure you have installed Python and VScode for the first lecture.
+- [Chapter 1](content/chapters/python/preface.qmd) - [Chapter 7](content/chapters/python/course_tools.qmd)
+
+### Lectures:
+
 - In the first lecture, I will outline how the course is organized and how you will get the most out of your efforts in learning programming.
 - In the first lecture, I will also talk about how a Python program works and about values, math, and logic.
 - In the second lecture, I will talk about variables, operators, substitution, and reduction.
 
-##### Exercises:  
-If you have yet to do so at home, you will install Python and the text editor. To do this, follow the instructions "Before you begin". Then, start doing the exercises in the other three chapters. You will also have time to do these exercises in the TA session of week two, so go slow. It is important to properly absorb the basic concepts at the beginning of the course; otherwise, it will become too difficult later on.
+### Exercises:  
+If you have yet to do so at home, you will install Python and the text editor. To do this, follow the instructions ["Before you begin"](content/chapters/python/before_you_begin.qmd). Then, start doing the exercises in the other three chapters. You will also have time to do these exercises in the TA session of week two, so go slow. It is important to properly absorb the basic concepts at the beginning of the course; otherwise, it will become too difficult later on.
 
 
 
 ## Week 2 {.unnumbered}
 
-##### Reading:  
-I will cover chapters 8-9 in the lecture notes.
+### Reading:
 
-##### Lectures:  
+I will cover chapters 8-9 in the lecture notes.
+- [Chapter 8](content/chapters/python/controlling_behavior.qmd)
+- [Chapter 9](content/chapters/python/organizing_your_code.qmd)
+
+### Lectures:
+
 - In the first lecture, I will talk about how to use logic to control which statements in your program that get executed.
 - In the first lecture, I will also talk about how you can efficiently organize your code using functions.
 - In the second lecture, I will talk more about functions.
 
-##### Exercises:  
+### Exercises:
+
 The topics for this week's exercises are statements, variables, operators, expressions, substitution, reduction, and logic. You will work on the rest of the exercises in last week's curriculum for the TA session. Do what you can at home and do the rest at the TA session.
+
+- [Chapter 1](content/chapters/python/preface.qmd) - [Chapter 7](content/chapters/python/course_tools.qmd)
 
 
 
 ## Week 3 {.unnumbered}
 
-**Reading Material**  
-I will cover chapters 10-13 in the lecture notes.
+### Reading:
 
-##### Lectures:  
+I will cover chapters 10-13 in the lecture notes.
+- [Chapter 10](content/chapters/python/python_values_are_objects.qmd)
+- [Chapter 11](content/chapters/python/lists.qmd)
+- [Chapter 12](content/chapters/python/dictionaries.qmd)
+- [Chapter 13](content/chapters/python/gluing_values_in_sequence.qmd)
+
+
+### Lectures:
+
 - In the first lecture, I will talk about objects and methods. 
 - In the first lecture, I will also talk about lists.
 - In the second lecture, I will talk about dictionaries and a bit about tuples.
 
-##### Exercises:  
+### Exercises:
+
 The topics for this week's exercises are if, else, logic, and functions. You are meant to complete all the exercises in the curriculum from last week. Do what you can at home and do the rest at the TA session.
 
+- [Chapter 8](content/chapters/python/controlling_behavior.qmd) 
+- [Chapter 9](content/chapters/python/organizing_your_code.qmd)
 
 
-### Week 4 {.unnumbered}
 
-**Reading Material**  
+## Week 4 {.unnumbered}
+
+### Reading: 
+
 I will cover chapters 14-15 in the lecture notes.
+- [Chapter 14](content/chapters/python/iteration_over_values.qmd)
+- [Chapter 15](content/chapters/python/working_with_data_files.qmd)
 
-##### Lectures:  
+### Lectures:
+
 - In the first lecture, I will talk about iteration and lists.
 - In the second lecture, I will talk about how your code can interact with files on your computer.
 
-
-##### Exercises:  
+### Exercises:
 
 ::: {.callout-note}
 Only MO and Bio classes attend the exercises this week. MM classes do not. The exercise is repeated next week for the MM classes to attend*
@@ -65,49 +96,69 @@ Only MO and Bio classes attend the exercises this week. MM classes do not. The e
 
 The topics for this week are objects, methods, strings, lists, tuples, and dictionaries. You are meant to complete all the exercises in the curriculum from last week. Do what you can at home and do the rest at the TA session.
 
+- [Chapter 10](content/chapters/python/python_values_are_objects.qmd) 
+- [Chapter 11](content/chapters/python/lists.qmd)
+- [Chapter 12](content/chapters/python/dictionaries.qmd)
+- [Chapter 13](content/chapters/python/gluing_values_in_sequence.qmd)
 
 
-### Week 5 {.unnumbered}
 
-**Reading Material**  
+## Week 5 {.unnumbered}
 
-- Chapters 16-18 in the lecture notes
-- [Chapter 11: Genomewide Association Studies](https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1002822)
-- [Benefits and limitations of genomewide association studies](https://www.nature.com/articles/s41576-019-0127-1)
+### Reading:
 
-##### Lectures:  
+Chapters 16-18 in the lecture notes.
+- [Chapter 16](content/chapters/python/data_structures.qmd) 
+- [Chapter 17]
+- [Chapter 18](content/chapters/python/testing_your_code.qmd)
+
+- [Bush WS, Moore JH (2012) Chapter 11: Genome-Wide Association Studies. *PLOS Computational Biology*](https://doi.org/10.1371/journal.pcbi.1002822)
+- [Benefits and limitations of genomewide association studies, *Nature Reviews Genetics*](https://doi.org/10.1038/s41576-019-0127-1)
+
+### Lectures:
+
 - In the first lecture, I will talk about databases, genotyping arrays, and genomewide association studies (GWAS).
 - In the first lecture, I will also talk about building simple data strutures in Python.
 - In the second lecture, I will talk about how to use recursion in Python.
 
-##### Exercises:  
+### Exercises:
 
 ::: {.callout-note}
 Only MM classes attend the exercises this week. MO and Bio classes do not. The exercise is repeated from last week*.
 :::
 
-The topics for this week are iteration and data structures. You are meant to complete all the exercises in the curriculum from last week. 
+The topics for this week are iteration and data structures. You are meant to complete all the exercises in the curriculum from last week.
+
+- [Chapter 10](content/chapters/python/python_values_are_objects.qmd) 
+- [Chapter 11](content/chapters/python/lists.qmd)
+- [Chapter 12](content/chapters/python/dictionaries.qmd)
+- [Chapter 13](content/chapters/python/gluing_values_in_sequence.qmd)
 
 
 
-### Week 6 {.unnumbered}
+## Week 6 {.unnumbered}
 
-**Reading Material**  
+### Reading:
 
-- Chapter 19 in the lecture notes
+- Chapter 19 in the lecture notes [Translating ORFs](content/chapters/project/translation_project.qmd)
 - Understanding Bioinformatics 127-141
 
-##### Lectures:  
+### Lectures:
 
 - In the first lecture, I will talk about global pairwise alignment In the first lecture
 - In the first lecture, I will also talk about the weekly programming project. 
 - In the second lecture, I will talk about local pairwise alignment and more realistic gap scoring.
 
-##### Exercises:  
+### Exercises:
 
-- The programming project described inthe lecture note reading for this week.
+- [Chapter 16](content/chapters/python/data_structures.qmd) 
+- [Chapter 17]
+- [Chapter 18](content/chapters/python/testing_your_code.qmd)
+- [Chapter 19: Translating ORFs](content/chapters/project/translation_project.qmd)
 
-From the [project files](supplementary/project_files.qmd) page, you can download the files you need for programming projects. There will be lots of work, so do what you can at home and do the rest at the TA session.
+
+From the [project files](supplementary/project_files.qmd) page, you can download the files you need for programming projects. 
+There will be lots of work, so do what you can at home and do the rest at the TA session.
 
 ::: {.callout-important}
 "Translating open reading frames" is a mandatory project. The deadline for handing it in (on Brightspace) is the night before your exercise class in week 41.
@@ -115,88 +166,90 @@ From the [project files](supplementary/project_files.qmd) page, you can download
 
 
 
-### Week 7 {.unnumbered}
+## Week 7 {.unnumbered}
 
-##### Reading:  
+### Reading:
 
-- Chapter 20 in the lecture notes
 - Understanding Bioinformatics: 117-127
 - Alignment methods: strategies, challenges, benchmarking, and comparative overview (don't do the exercises).
+- [Chapter 20](content/chapters/project/folding_project.qmd)
 
-##### Lectures:  
+### Lectures:
 
 - In the first lecture, I will talk about protein substitution matrices and how to score protein alignments. - In the first lecture, I will also talk Python classes and the weekly programming project.
 - In the second lecture, I will talk about multiple alignment.
 
-##### Exercises:  
+### Exercises:
 
 - The web exercise: [GWAS candidates](chapters/web/gwas_databases.qmd)
-- The programming project described inthe lecture note reading for this week.
+- [Chapter 20](content/chapters/project/folding_project.qmd)
 
 From the [project files](supplementary/project_files.qmd) page, you can download the files you need for both programming projects and web exercises. There will be lots of work, so do what you can at home and do the rest at the TA session.
 
 
 
-### Week 8 {.unnumbered}
+## Week 8 {.unnumbered}
 
-##### Reading:  
+### Reading:
 
-- Chapter 21 in the lecture notes
+- [Chapter 21 in the lecture notes](content/chapters/project/alignment_project.qmd)
 - Bioinformatics Explained: BLAST
 - Biological Sequence Analysis pp. 192-197
 
-##### Lectures:  
+### Lectures:
 
 - In the first lecture, I will talk about how to search for matches in a sequence database and how to asses alignment significance.
 - In the first lecture, I will also talk about programming topics and the weekly programming project.
 - In the second lecture, I will talk about models of DNA evolution and how to measure evolutionary distance between sequences.
 
-##### Exercises:  
+### Exercises:
 
 - The web exercise: [CCR5-delta32](chapters/web/ccr5_pwalign.qmd)
-- The programming project described inthe lecture note reading for this week.
+- [Chapter 21 in the lecture notes](content/chapters/project/alignment_project.qmd)
 
 From the [project files](supplementary/project_files.qmd) page, you can download the files you need for both programming projects and web exercises. There will be lots of work, so do what you can at home and do the rest at the TA session.
 
 
 
-### Week 9 {.unnumbered}
+## Week 9 {.unnumbered}
 
-##### Reading:  
+### Reading:
 
-- Chapter 22 in the lecture notes
+- [Chapter 22 in the lecture notes](content/chapters/project/codonbias_project.qmd)
 - Biological Sequence Analysis pp. 165-179  <!-- UPGMA / NJ -->
 
-##### Lectures:  
+### Lectures:
 
 - In the first lecture, I will talk about methods for sequence clustering. 
 - In the first lecture, I will also talk about the programming project.
 - In the second lecture, I will talk about bioinformatics code libraries for Python, such as BioPython, and the Master in Bioinformatics that we offer at the Bioinformatics Centre.
 
-##### Exercises:  
+### Exercises:
+
 - The web exercise: [MRSA](chapters/web/mrsa_blast_multalign.qmd)
-- The programming project described inthe lecture note reading for this week.
+- [Chapter 22 in the lecture notes](content/chapters/project/codonbias_project.qmd)
 
 From the [project files](supplementary/project_files.qmd) page, you can download the files you need for both programming projects and web exercises. There will be lots of work, so do what you can at home and do the rest at the TA session.
 
 
 
-### Week 10 {.unnumbered}
+## Week 10 {.unnumbered}
 
-##### Reading:  
+### Reading:
 
-- Chapter 23 in the lecture notes
+- [Chapter 23 in the lecture notes](content/chapters/project/hiv_project.qmd)
 - Biological Sequence Analysis pp. 192-202 <!-- phylogeny / felsenstein -->
 
-##### Lectures:  
+### Lectures:
 
 - In the first lecture, I will talk about phylogenetic trees.
 - In the first lecture, I will also talk about Python topics and the weekly programming project.
 - In the second lecture, I will talk about gene prediction in prokaryotes.
 
-##### Exercises:  
+### Exercises:
+
 - The web exercise: [Aardvark?](chapters/web/aardwark_seqdist.qmd)
-- The programming project described inthe lecture note reading for this week.
+- [Chapter 23 in the lecture notes](content/chapters/project/hiv_project.qmd)
 
 From the [project files](supplementary/project_files.qmd) page, you can download the files you need for both programming projects and web exercises. There will be lots of work, so do what you can at home and do the rest at the TA session.
 
@@ -208,31 +261,32 @@ The programming project "Identifying the subtype of an HIV sequence" is a mandat
 
 
 
-### Week 11 {.unnumbered}
+## Week 11 {.unnumbered}
 
-##### Reading:  
+### Reading:
 
-- Chapter 24 in the lecture notes
+- [Chapter 24 in the lecture notes](content/chapters/project/seqdist_project.qmd)
 - Biological Sequence Analysis pp. 46-66 <!-- HMMs -->
 
 ### Lectures
+
 - In the first lecture, I will talk about hidden Markov models (HMMs).
 - In the first lecture, I will also talk about python topics and the weekly programming project.
 - In the second lecture, I will talk about more about HMMs
 
-##### Exercises:  
+### Exercises:
 
-- The programming project described inthe lecture note reading for this week.
+- [Chapter 24 in the lecture notes](content/chapters/project/seqdist_project.qmd)
 
 From the [project files](supplementary/project_files.qmd) page, you can download the files you need for both programming projects and web exercises. There will be lots of work, so do what you can at home and do the rest at the TA session.
 
 
 
-### Week 12 {.unnumbered}
+## Week 12 {.unnumbered}
 
-##### Reading:  
+### Reading:
 
-- Chapter 25 in the lecture notes
+- [Chapter 25 in the lecture notes: Finding genes](content/chapters/project/orf_project.qmd)
 - Understanding Bioinformatics pp. 438-448 <!--protein prediction -->
 - [Automatic generation of gene finders for Eukaryotic species](https://bmcbioinformatics.biomedcentral.com/articles/10.1186/1471-2105-7-263)
 - [The Theory and Practice of Genome Sequence Assembly](https://www.annualreviews.org/doi/10.1146/annurev-genom-090314-050032) <!-- genome assembly -->
@@ -243,48 +297,52 @@ From the [project files](supplementary/project_files.qmd) page, you can download
 - In the first lecture, I will also talk about Python topics and the weekly programming project.
 - In the second lecture, I will talk genome assembly.
 
-##### Exercises:  
+### Exercises:
+
 - The web exercise: [Plasmid ORFs](chapters/web/orf_finding.qmd)
-- The programming project described inthe lecture note reading for this week.
+- [Chapter 25: Finding genes](content/chapters/project/orf_project.qmd)
 
 From the [project files](supplementary/project_files.qmd) page, you can download the files you need for both programming projects and web exercises. There will be lots of work, so do what you can at home and do the rest at the TA session.
 
 
 
-### Week 13 {.unnumbered}
+## Week 13 {.unnumbered}
 
-##### Reading:  
+### Reading:
 
-- Chapter 26 in the lecture notes
+- [Chapter 26 in the lecture notes: Genome assembly](content/chapters/project/assembly_project.qmd)
 - Understanding Bioinformatics pp. 494-496  <!-- Neural networks -->
 - Exploring Bioinformatics pp. 242-248  <!-- RNA structure -->
 
 ### Lectures
+
 - In the first lecture, I will talk about neural networks
 - In the first lecture, I will also talk about the programming project.
 - In the second lecture, I will talk about RNA secondary structure prediction.
 
-##### Exercises:  
+### Exercises:
+
 - The web exercise: [Read mapping](chapters/web/long_reads.qmd)
-- The programming project described inthe lecture note reading for this week.
+- [Chapter 26 in the lecture notes: Genome assembly](content/chapters/project/assembly_project.qmd)
 
 From the [project files](supplementary/project_files.qmd) page, you can download the files you need for both programming projects and web exercises. There will be lots of work, so do what you can at home and do the rest at the TA session.
 
 
 
-### Week 14 {.unnumbered}
+## Week 14 {.unnumbered}
 
-##### Reading:  
+### Reading:
 
 - None this week.
 
-##### Lectures:  
+### Lectures:
 
 <!-- TODO: Add toic for lecture in week 14 -->
 - In the first lecture, I will talk about python and algorithms. You will also hear a guest talk by about bioinformatics outside the class room.
 - In the last lecture, we will evaluate the course and review the exam's practicalities.
 
-##### Exercises:  
+### Exercises:
+
 - The web exercise: [Neural networks](chapters/web/neural_networks.qmd)
 - The programming project described inthe lecture note reading for this week.
 


### PR DESCRIPTION
Header levels set throughout document. Trailing whitespaces removed. Empty lines inserted below each header and three empty lines inserted if the next header has a higher level than the previous.

References updated with hyperlinks for the chapters in the book. References for some articles updated to link to DOI.